### PR TITLE
Improve comparison of non-semver versions (fixes #7)

### DIFF
--- a/backend/api/version.js
+++ b/backend/api/version.js
@@ -1,29 +1,49 @@
 const semver = require("semver");
 const lookupVersion = require("../lib/utils");
 
+const diffLoose = (version1, version2) => {
+  if (semver.eq(version1, version2, true)) {
+    return null;
+  }
+  const v1 = semver.parse(version1, true);
+  const v2 = semver.parse(version2, true);
+  let prefix = "";
+  let defaultResult = null;
+  if (v1.prerelease.length || v2.prerelease.length) {
+    prefix = "pre";
+    defaultResult = "prerelease";
+  }
+  for (let key in v1) {
+    if (v1.hasOwnProperty(key) && ["major", "minor", "patch"].includes(key) && v1[key] !== v2[key]) {
+      return prefix + key;
+    }
+  }
+  return defaultResult;
+};
+
 const versionCompare = (currentVersion, latestVersion) => {
   if (!latestVersion) {
     return {
       needsUpdate: false,
       updateType: null,
-      notice: 'Error: could not get latest version'
+      notice: "Error: could not get latest version"
     };
   }
 
   try {
-    const needsUpdate = semver.lt(currentVersion, latestVersion);
-    const updateType = needsUpdate ? semver.diff(currentVersion, latestVersion) : null;
+    const needsUpdate = semver.lt(currentVersion, latestVersion, true);
+    const updateType = needsUpdate ? diffLoose(currentVersion, latestVersion) : null;
     return {
       needsUpdate,
       updateType
     };
   } catch (e) {
-    const needsUpdate = currentVersion !== latestVersion;
-    const updateType = needsUpdate ? 'minor' : null;
+    const needsUpdate = currentVersion !== latestVersion && (latestVersion > currentVersion);
+    const updateType = needsUpdate ? "minor" : null;
     return {
       needsUpdate,
       updateType,
-      notice: e.message
+      notice: e.message.replace(/^Invalid Version:/, "Not a valid semver version:")
     };
   }
 };


### PR DESCRIPTION
This helps make sure that comparisons between versions like 1.7 and 1.8 (not strictly semver valid) will produce the correct output for the `needsUpdate` value.