### PR TITLE
Add country as parameter for App Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ if (version.needsUpdate) {
 `checkVersion()` accepts an _optional_ options object, which may contain the following keys:
 
 - string `platform`: platform to check for, defaults to React Native's `Platform.OS`
+- string `country`: App Store specific country, defaults to `us`
 - string `bundleId`: bundle identifier to check, defaults to the value retrieved using react-native-device-info
 - string `currentVersion`: version to check against, defaults to the currently installed version
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -30,7 +30,7 @@ Bundle ID should be the Bundle Identifier of your app (e.g. `com.includable.exam
 }
 ```
 
-### `GET /:platform/:country/:bundleId/:currentVersion`
+### `GET /:platform/:bundleId/:currentVersion`
 
 Compare a current `semver` version number to the latest version of the bundle.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -30,7 +30,7 @@ Bundle ID should be the Bundle Identifier of your app (e.g. `com.includable.exam
 }
 ```
 
-### `GET /:platform/:bundleId/:currentVersion`
+### `GET /:platform/:country/:bundleId/:currentVersion`
 
 Compare a current `semver` version number to the latest version of the bundle.
 

--- a/backend/api/get.js
+++ b/backend/api/get.js
@@ -1,8 +1,9 @@
 const lookupVersion = require("../lib/utils");
 
-module.exports.handler = async({ pathParameters: { platform, bundleId } }) => {
+module.exports.handler = async({ pathParameters: { platform, bundleId }, queryStringParameters }) => {
   try {
-    const data = await lookupVersion(platform, bundleId);
+    const country = queryStringParameters && queryStringParameters.country || 'us';
+    const data = await lookupVersion(platform, bundleId, country);
     return {
       statusCode: 200,
       body: JSON.stringify({ platform, bundleId, ...data })

--- a/backend/api/version.js
+++ b/backend/api/version.js
@@ -51,9 +51,9 @@ const versionCompare = (currentVersion, latestVersion) => {
   }
 };
 
-module.exports.handler = async({ pathParameters: { platform, bundleId, currentVersion } }) => {
+module.exports.handler = async({ pathParameters: { platform, bundleId, currentVersion, country } }) => {
   try {
-    const data = await lookupVersion(platform, bundleId);
+    const data = await lookupVersion(platform, bundleId, country);
     const version = versionCompare(currentVersion, data.version);
     return {
       statusCode: 200,

--- a/backend/api/version.js
+++ b/backend/api/version.js
@@ -51,8 +51,9 @@ const versionCompare = (currentVersion, latestVersion) => {
   }
 };
 
-module.exports.handler = async({ pathParameters: { platform, bundleId, currentVersion, country } }) => {
+module.exports.handler = async({ pathParameters: { platform, bundleId, currentVersion }, queryStringParameters }) => {
   try {
+    const country = queryStringParameters && queryStringParameters.country || 'us';
     const data = await lookupVersion(platform, bundleId, country);
     const version = versionCompare(currentVersion, data.version);
     return {

--- a/backend/lib/utils.js
+++ b/backend/lib/utils.js
@@ -2,7 +2,7 @@ const axios = require("axios");
 
 const cache = {}
 
-const lookupVersion = async(platform, bundleId) => {
+const lookupVersion = async(platform, bundleId, country = 'us') => {
   const key = `${platform}.${bundleId}`;
   let res = cache[key];
   if (res) {
@@ -12,7 +12,7 @@ const lookupVersion = async(platform, bundleId) => {
   let url;
   switch (platform) {
   case "ios":
-    url = `http://itunes.apple.com/lookup?lang=en&bundleId=${bundleId}`;
+    url = `http://itunes.apple.com/lookup?lang=en&bundleId=${bundleId}&country=${country}`;
     res = await axios.get(url);
     if (!res.data || !("results" in res.data)) {
       throw new Error("Unknown error connecting to iTunes.");

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -58,6 +58,10 @@ functions:
           path: /{platform}/{bundleId}/{currentVersion}
           method: get
           cors: true
+      - http:
+          path: /{platform}/{country}/{bundleId}/{currentVersion}
+          method: get
+          cors: true
 
 # CloudFormation resources
 resources:

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -51,6 +51,9 @@ functions:
           path: /{platform}/{bundleId}
           method: get
           cors: true
+          request:
+            querystrings:
+              country: false
   version:
     handler: api/version.handler
     events:
@@ -58,10 +61,9 @@ functions:
           path: /{platform}/{bundleId}/{currentVersion}
           method: get
           cors: true
-      - http:
-          path: /{platform}/{country}/{bundleId}/{currentVersion}
-          method: get
-          cors: true
+          request:
+            querystrings:
+              country: false
 
 # CloudFormation resources
 resources:

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ export const checkVersion = async(options = {}) => {
   }
 
   // Compile into URL
-  const url = `${endpoint}/${platform}/${country}/${bundleId}/${currentVersion}`;
+  const url = `${endpoint}/${platform}/${bundleId}/${currentVersion}?country=${country}`;
   if (CACHE[url]) {
     return CACHE[url];
   }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import { Platform, NativeModules } from "react-native";
 import pkg from "./package.json";
 
 const DEFAULT_ENDPOINT = "https://check-version.flexible.agency";
+const DEFAULT_COUNTRY = "us";
 const CACHE = {}; // In-memory temporary cache
 
 // noinspection JSUnusedGlobalSymbols
@@ -9,6 +10,7 @@ export const checkVersion = async(options = {}) => {
   // Get options object
   const endpoint = options.endpoint || DEFAULT_ENDPOINT;
   const platform = options.platform || Platform.OS;
+  const country = options.country || DEFAULT_COUNTRY;
   const bundleId = options.bundleId || (NativeModules.RNDeviceInfo
     ? NativeModules.RNDeviceInfo.bundleId
     : null);
@@ -25,7 +27,7 @@ export const checkVersion = async(options = {}) => {
   }
 
   // Compile into URL
-  const url = `${endpoint}/${platform}/${bundleId}/${currentVersion}`;
+  const url = `${endpoint}/${platform}/${country}/${bundleId}/${currentVersion}`;
   if (CACHE[url]) {
     return CACHE[url];
   }


### PR DESCRIPTION
When the app is published in some non-us country, this can't be found using the current method.
Added a new parameter `country` that allows to pass a custom country in order to get the proper bundleId.