### PR TITLE
Deal better with non-semver versions like '1.1' and '11'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16
-          cache: 'yarn'
       - name: Install dependencies
         run: yarn && cd backend && yarn
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,12 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16
+          cache: 'yarn'
       - name: Install dependencies
-        run: yarn
+        run: yarn && cd backend && yarn
       - name: Run tests
         run: yarn test

--- a/tests/version.test.js
+++ b/tests/version.test.js
@@ -1,0 +1,68 @@
+import { versionCompare } from "../backend/api/version";
+
+describe('Version compare', () => {
+  it('deals with real semvers', () => {
+    expect(versionCompare('1.1.2', '1.1.3')).toEqual({
+      needsUpdate: true,
+      updateType: 'patch'
+    });
+    expect(versionCompare('1.1.2', '1.1.2')).toEqual({
+      needsUpdate: false,
+      updateType: null
+    });
+    expect(versionCompare('1.2.0', '1.1.3')).toEqual({
+      needsUpdate: false,
+      updateType: null
+    });
+    expect(versionCompare('1.1.1', '1.2.0')).toEqual({
+      needsUpdate: true,
+      updateType: 'minor'
+    });
+    expect(versionCompare('0.9.0', '1.2.0')).toEqual({
+      needsUpdate: true,
+      updateType: 'major'
+    });
+  });
+
+  it('deals with simple decimal versions', () => {
+    expect(versionCompare('1.1', '1.2')).toEqual({
+      needsUpdate: true,
+      updateType: 'minor'
+    });
+    expect(versionCompare('1.1', '1.1')).toEqual({
+      needsUpdate: false,
+      updateType: null
+    });
+    expect(versionCompare('1.2', '1.1')).toEqual({
+      needsUpdate: false,
+      updateType: null
+    });
+    expect(versionCompare('0.9', '1.2')).toEqual({
+      needsUpdate: true,
+      updateType: 'major'
+    });
+  });
+
+  it('deals with single-number versions', () => {
+    expect(versionCompare('11', '12')).toEqual({
+      needsUpdate: true,
+      updateType: 'major'
+    });
+    expect(versionCompare('11', '11')).toEqual({
+      needsUpdate: false,
+      updateType: null
+    });
+    expect(versionCompare('12', '11')).toEqual({
+      needsUpdate: false,
+      updateType: null
+    });
+    expect(versionCompare('9', '12')).toEqual({
+      needsUpdate: true,
+      updateType: 'major'
+    });
+    expect(versionCompare('944', '1201')).toEqual({
+      needsUpdate: true,
+      updateType: 'major'
+    });
+  });
+});


### PR DESCRIPTION
Added some logic to better deal with versions that aren't valid semvers, by using the `semver.coerce()` function.

Added tests for some of these basic cases as well.