### PR TITLE
Added lastChecked & country types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,8 @@ export interface CheckVersionResponse {
   updateType?: CheckVersionUpdateType;
   platform?: PlatformOSType;
   bundleId?: string;
+  lastChecked?: string;
+  country?: string;
 }
 
 declare const checkVersion: (


### PR DESCRIPTION
Added types to CheckVersionResponse interface.

Hi, first of all, great tool!
I was checking this package using typescript and I noticed that for the interface "CheckVersionResponse", the two properties that were recently added weren't present so I added them!

Sorry if this is not your way to publish PRs. Please let me know if there's something else I should do!