### PR TITLE
fix android release date and notes

### DIFF
--- a/backend/lib/utils.js
+++ b/backend/lib/utils.js
@@ -26,7 +26,7 @@ const lookupVersion = async(platform, bundleId, country = 'us') => {
   let url;
   switch (platform) {
   case "ios":
-    url = `http://itunes.apple.com/lookup?lang=en&bundleId=${bundleId}&country=${country}`;
+    url = `https://itunes.apple.com/lookup?lang=en&bundleId=${bundleId}&country=${country}`;
     res = await axios.get(url);
     if (!res.data || !("results" in res.data)) {
       throw new Error("Unknown error connecting to iTunes.");

--- a/backend/lib/utils.js
+++ b/backend/lib/utils.js
@@ -1,5 +1,6 @@
 const axios = require("axios");
-const dateFns = require('date-fns');
+const dateFns = require("date-fns");
+const { convert } = require("html-to-text");
 
 const cache = {}
 
@@ -64,14 +65,19 @@ const lookupVersion = async(platform, bundleId, country = 'us') => {
     // Version
     const version = getTokenValue("Current Version", "Requires", resData)
 
+    // Release Notes
+    const notes = (getTokenValue("What&#39;s New", "Additional Information", resData)).replace('Read moreCollapse', '');
+
     // Release Date
     const released = dateFns.parse(getTokenValue("Updated", "Size", resData), 'LLLL d, yyyy', new Date());
 
 
     res = {
       version: version || null,
-      released: (released).toISOString(),
-      notes: "",
+      releasedAt: (released).toISOString() || (new Date()).toISOString(),
+      notes: convert(notes, {
+        wordwrap: false
+      }) || "",
       url: `https://play.google.com/store/apps/details?id=${bundleId}`,
       lastChecked: (new Date()).toISOString()
     };

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "axios": "^0.21.4",
     "date-fns": "^2.25.0",
+    "html-to-text": "^8.1.0",
     "semver": "^7.3.5"
   },
   "devDependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "axios": "^0.21.4",
+    "date-fns": "^2.25.0",
     "semver": "^7.3.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Current release date just returns you today's date instead of taking the release date from Google Play.

Notes is missing too.

This fixes it.

Had to add `html-to-text` to convert HTML code to text to be more in-line with the ios release notes