### PR TITLE
Prevent CDN caching by appending random number to iTunes lookup service

### DIFF
--- a/backend/lib/utils.js
+++ b/backend/lib/utils.js
@@ -12,7 +12,8 @@ const lookupVersion = async(platform, bundleId, country = 'us') => {
   let url;
   switch (platform) {
   case "ios":
-    url = `http://itunes.apple.com/lookup?lang=en&bundleId=${bundleId}&country=${country}`;
+    // Adds a random number to the end of the URL to prevent caching
+    url = `http://itunes.apple.com/lookup?lang=en&bundleId=${bundleId}&country=${country}&_=${new Date().valueOf()}`;
     res = await axios.get(url);
     if (!res.data || !("results" in res.data)) {
       throw new Error("Unknown error connecting to iTunes.");


### PR DESCRIPTION
This PR adds a random number (current timestamp) to the URL query parameters for the iTunes lookup API call, to prevent CDN caching on Apple's side from delaying updates showing up in the app.

This seems to be especially important if the country code requested doesn't match the country of the client making the call, which is almost always the case with our service, since it is hosted in Amazon's eu-west-1 (Ireland) region.

Fixes #23 - thanks for bringing this up @preflower!