### PR TITLE
fix: remove caching

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,15 +1,7 @@
 import { getIosVersion } from "./providers/ios";
 import { getAndroidVersion } from "./providers/android";
 
-const cache = {};
-
 export const lookupVersion = async(platform, bundleId, country = "us") => {
-  const key = `${platform}.${bundleId}`;
-  let res = cache[key];
-  if (res) {
-    return res;
-  }
-
   switch (platform) {
   case "ios":
     res = await getIosVersion(bundleId, country);
@@ -21,6 +13,5 @@ export const lookupVersion = async(platform, bundleId, country = "us") => {
     throw new Error("Unsupported platform defined.");
   }
 
-  cache[key] = res;
   return res;
 };


### PR DESCRIPTION
Remove caching from lookupVersion function. This can be executed multiple times now that a backend does not handle it. 

Caching can lead to returning a wrong version to the user when the new version shows up in the store after the version was checked, which can potentially lead to misleading information about the update in the app, or it won't show at all.