### PR TITLE
feat: Add more information for android and ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ const version = await checkVersion();
 console.log("Got version info:", version);
 
 if (version.needsUpdate) {
-   console.log(`App has a ${version.updateType} update pending.`);
+  console.log(`App has a ${version.updateType} update pending.`);
 }
 ```
 
@@ -48,12 +48,21 @@ if (version.needsUpdate) {
 `checkVersion()` returns a Promise, which when resolved will return an object with the following properties:
 
 - string `version`: latest version number of the app
-- string `released`: (iOS only) ISO 8601 release date of that version
+- string `releasedAt`: ISO 8601 release date of that version (when available)
+- string `updatedAt`: ISO 8601 last update date of that version (when available)
 - string `url`: download URL for the latest version
-- string `notes`: release notes of latest version
+- string `notes`: release notes for the latest version (when available)
+- string `appIcon`: app icon URL (when available)
+- string `appName`: app name (when available)
+- string `description`: app description (when available)
 - boolean `needsUpdate`: whether the latest version number is higher than the currently installed one
 - string `updateType`: `major`, `minor` or `patch`, based on how big the difference is between the currently installed
   version and the available version
+- string `platform`: resolved platform used for the lookup
+- string `bundleId`: resolved bundle ID used for the lookup
+- string `country`: resolved country used for the lookup
+- string `lastChecked`: ISO 8601 timestamp of the lookup
+- Error `error`: error information when the lookup fails
 
 ## Changelog
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,16 +11,21 @@ export interface CheckVersionOptions {
 }
 
 export interface CheckVersionResponse {
-  version: string;
-  released?: Date; // iOS only
-  url: string;
-  notes?: string; // iOS only
+  version: string | null;
+  releasedAt?: string;
+  updatedAt?: string;
+  url: string | null;
+  notes?: string;
+  appIcon?: string;
+  appName?: string;
+  description?: string;
   needsUpdate: boolean;
-  updateType?: CheckVersionUpdateType;
+  updateType?: CheckVersionUpdateType | null;
   platform?: PlatformOSType;
   bundleId?: string;
   lastChecked?: string;
   country?: string;
+  notice?: string;
   error?: Error;
 }
 

--- a/src/providers/android.js
+++ b/src/providers/android.js
@@ -26,16 +26,16 @@ export const getAndroidVersion = async (bundleId, country) => {
   const version = text.match(/\[\[\["([0-9A-Za-z.\-_]+)"\]\]/)?.[1] ||
     text.match(/]],"(\d+\.\d+\.\d+\.\d+)",null,\[\[\[/)?.[1];
   const notes = text.match(/itemprop="description">(.*?)<\/div>/)?.[1];
-  const updateAt = text.match(/<div class="xg1aie">(.*?)<\/div>/)?.[1];
+  const updatedAt = text.match(/<div class="xg1aie">(.*?)<\/div>/)?.[1];
   const releasedAt = text.match(/\["([^"]+)",\[\d+,\d+\]\]/)?.[1];
   const appIcon = text.match(/<meta property="og:image" content="([^"]+)"/,)?.[1];
   const appName = text.match(/<title.*?>(.*?) (–|-)/)?.[1];
   const description = text.match(/<meta name="description" property="og:description" content="([^"]+)"/,)?.[1];
 
   return {
-    version: version || "",
+    version: version || null,
     releasedAt: releasedAt || "",
-    updateAt: updateAt || "",
+    updatedAt: updatedAt || "",
     notes: notes || "",
     url: `https://play.google.com/store/apps/details?id=${bundleId}&hl=${country}`,
     country: country || "",

--- a/src/providers/android.js
+++ b/src/providers/android.js
@@ -23,16 +23,26 @@ export const getAndroidVersion = async (bundleId, country) => {
   }
 
   const text = await res.text();
-  const version = text.match(/\[\[\[['"]((\d+\.)+\d+)['"]\]\],/)[1];
-  const notes = text.match(/<div itemprop="description">(.*?)<\/div>/)?.[1];
+  const version = text.match(/\[\[\["([0-9A-Za-z.\-_]+)"\]\]/)?.[1] ||
+    text.match(/]],"(\d+\.\d+\.\d+\.\d+)",null,\[\[\[/)?.[1];
+  const notes = text.match(/itemprop="description">(.*?)<\/div>/)?.[1];
   const updateAt = text.match(/<div class="xg1aie">(.*?)<\/div>/)?.[1];
+  const releasedAt = text.match(/\["([^"]+)",\[\d+,\d+\]\]/)?.[1];
+  const appIcon = text.match(/<meta property="og:image" content="([^"]+)"/,)?.[1];
+  const appName = text.match(/<title.*?>(.*?) (–|-)/)?.[1];
+  const description = text.match(/<meta name="description" property="og:description" content="([^"]+)"/,)?.[1];
 
   return {
-    version: version || null,
-    releasedAt: (new Date()).toISOString(),
+    version: version || "",
+    releasedAt: releasedAt || "",
     updateAt: updateAt || "",
     notes: notes || "",
     url: `https://play.google.com/store/apps/details?id=${bundleId}&hl=${country}`,
-    lastChecked: (new Date()).toISOString()
+    country: country || "",
+    bundleId: bundleId || "",
+    lastChecked: new Date().toISOString(),
+    appIcon: appIcon || "",
+    appName: appName || "",
+    description: description || "",
   };
 };

--- a/src/providers/ios.js
+++ b/src/providers/ios.js
@@ -15,9 +15,9 @@ export const getIosVersion = async (bundleId, country) => {
 
   const res = data.results[0];
   return {
-    version: res.version || "",
-    releasedAt: res.currentVersionReleaseDate || res.releaseDate || "",
-    updateAt: res.currentVersionReleaseDate || "",
+    version: res.version || null,
+    releasedAt: res.releaseDate || "",
+    updatedAt: res.currentVersionReleaseDate || "",
     notes: res.releaseNotes || "",
     url: res.trackViewUrl || res.artistViewUrl || res.sellerUrl || "",
     country: country || "",

--- a/src/providers/ios.js
+++ b/src/providers/ios.js
@@ -2,25 +2,29 @@ export const getIosVersion = async (bundleId, country) => {
   // Adds a random number to the end of the URL to prevent caching
   const url = `https://itunes.apple.com/lookup?bundleId=${bundleId}&country=${country}&_=${new Date().valueOf()}`;
 
-  let res = await fetch(url);
+  const response = await fetch(url);
 
-  const data = await res.json();
+  const data = await response.json();
 
-  if (!data || !("results" in data)) {
+  if (!data?.results) {
     throw new Error("Unknown error connecting to iTunes.");
   }
   if (!data.results.length) {
     throw new Error("App for this bundle ID not found.");
   }
 
-  res = data.results[0];
-
+  const res = data.results[0];
   return {
-    version: res.version || null,
-    released: res.currentVersionReleaseDate || res.releaseDate || null,
+    version: res.version || "",
+    releasedAt: res.currentVersionReleaseDate || res.releaseDate || "",
+    updateAt: res.currentVersionReleaseDate || "",
     notes: res.releaseNotes || "",
-    url: res.trackViewUrl || res.artistViewUrl || res.sellerUrl || null,
-    country,
-    lastChecked: (new Date()).toISOString()
+    url: res.trackViewUrl || res.artistViewUrl || res.sellerUrl || "",
+    country: country || "",
+    bundleId: bundleId || "",
+    lastChecked: new Date().toISOString(),
+    appIcon: res.artworkUrl512 || res.artworkUrl100 || "",
+    appName: res.trackName || "",
+    description: res.description || "",
   };
 };


### PR DESCRIPTION
Add more information for Android and iOS apps:

* Fixed `releasedAt` and `version` fields
* Added new fields: `appIcon`, `appName`,   `bundleId`, and `description`


Issue: https://github.com/tschoffelen/react-native-check-version/issues/76
Issue: https://github.com/tschoffelen/react-native-check-version/issues/54

demo : https://github.com/CarlosSTS/check-version-app